### PR TITLE
Make shader functions a bit more lispy.

### DIFF
--- a/shadow.asd
+++ b/shadow.asd
@@ -28,4 +28,5 @@
    (:file "uniforms")
    (:file "layout")
    (:file "blocks")
-   (:file "buffers")))
+   (:file "buffers")
+   (:file "glsl")))

--- a/src/glsl.lisp
+++ b/src/glsl.lisp
@@ -1,0 +1,45 @@
+(in-package #:shadow.glsl)
+
+(cl:defmacro defun (name args &body body)
+  "Define a GPU function."
+  (a:with-gensyms (split-details deps fn spec)
+    (let ((split-args (varjo.utils:split-arguments args '(&uniforms &context))))
+      (destructuring-bind (in-args uniforms context) split-args
+        `(varjo:with-constant-inject-hook
+             #'shadow::lisp-constant->glsl-constant
+           (varjo:with-stemcell-infer-hook
+               #'shadow::lisp-symbol->glsl-type
+             (let* ((,fn (varjo:add-external-function
+                          ',name ',in-args ',uniforms ',body))
+                    (,spec (shadow::get-function-spec ,fn)))
+               (when (shadow::meta :track-dependencies-p)
+                 (let* ((,split-details
+                          (varjo:test-translate-function-split-details
+                           ',name ',in-args ',uniforms ',context ',body))
+                        (,deps (varjo:used-external-functions
+                                (first ,split-details))))
+                   (shadow::store-function-dependencies ,spec ,deps)
+                   (funcall (shadow::meta :modify-hook)
+                            (shadow::compute-outdated-programs ,spec))))
+               ,fn))
+           (export ',name))))))
+
+(cl:defmacro defstruct (name &body slots)
+  "Define a GPU structure."
+  `(varjo:define-vari-struct ,name () ,@slots))
+
+(cl:defmacro defmacro (name lambda-list &body body)
+  "Define a GPU macro."
+  `(varjo:define-vari-macro ,name ,lambda-list ,@body))
+
+(cl:defmacro define-shader (name (&key (version :430) (primitive :triangles))
+                            &body body)
+  "Create a new shader program using the stage-specs defined in BODY.
+VERSION: The default version shader stages use, and can be overridden on a
+per-function basis.
+PRIMITIVE: The drawing primitive to use for the vertex stage."
+  `(u:eval-always
+     (setf (u:href (shadow::meta :shader-definitions) ',name)
+           (lambda ()
+             (shadow::%make-shader-program ',name ,version ,primitive ',body)))
+     (export ',name)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -5,9 +5,9 @@
                     (#:u #:golden-utils))
   (:use #:cl)
   (:export
-   #:define-function
-   #:define-struct
-   #:define-macro
+   #:defun
+   #:defstruct
+   #:defmacro
    #:define-shader
    #:load-shaders
    #:unload-shaders
@@ -47,3 +47,30 @@
    #:uniform-mat3-array
    #:uniform-mat4
    #:uniform-mat4-array))
+
+(defpackage #:shadow.glsl
+  (:local-nicknames (#:a #:alexandria)
+                    (#:u #:golden-utils))
+  (:use #:cl #:vari)
+  (:shadow
+   #:defun
+   #:defstruct
+   #:defmacro)
+  ;; export external CL and VARI symbols
+  #.(cons
+     :export
+     (flet ((find-symbols (&rest packages)
+              (let (symbols)
+                (dolist (package packages)
+                  (do-external-symbols (x package)
+                    (push x symbols)))
+                (nreverse symbols))))
+       (loop :for symbol :in (find-symbols '#:cl '#:vari)
+             :unless (member (symbol-name symbol)
+                             '("DEFUN" "DEFSTRUCT" "DEFMACRO"))
+               :collect symbol)))
+  (:export
+   #:defun
+   #:defstruct
+   #:defmacro
+   #:define-shader))

--- a/src/program.lisp
+++ b/src/program.lisp
@@ -112,18 +112,6 @@ See MAKE-SHADER-PROGRAM"
     (store-stage-program-dependencies program)
     program))
 
-(defmacro define-shader (name (&key (version :430) (primitive :triangles))
-                         &body body)
-  "Create a new shader program using the stage-specs defined in BODY.
-VERSION: The default version shader stages use, and can be overridden on a
-per-function basis.
-PRIMITIVE: The drawing primitive to use for the vertex stage."
-  `(u:eval-always
-     (setf (u:href (meta :shader-definitions) ',name)
-           (lambda ()
-             (%make-shader-program ',name ,version ,primitive ',body)))
-     (export ',name)))
-
 (defun translate-shader-programs (program-list)
   "Re-translate a collection of shader programs."
   (dolist (program-name program-list)

--- a/src/shadow.lisp
+++ b/src/shadow.lisp
@@ -45,14 +45,6 @@
     (build-shader-programs programs-list)
     (rebind-blocks programs-list)))
 
-(defmacro define-struct (name &body slots)
-  "Define a GPU structure."
-  `(varjo:define-vari-struct ,name () ,@slots))
-
-(defmacro define-macro (name lambda-list &body body)
-  "Define a GPU macro."
-  `(varjo:define-vari-macro ,name ,lambda-list ,@body))
-
 (setf (meta :track-dependencies-p) nil
       (meta :fn->deps) (u:dict #'equal)
       (meta :dep->fns) (u:dict #'equal)


### PR DESCRIPTION
Defines a dedicated package for writing shaders, SHADOW.GLSL. This automatically
exports all the symbols from CL and VARI so the user doesn't have to.
Additionally, DEFINE-SHADER is now DEFUN, DEFINE-STRUCT is now DEFSTRUCT, and
DEFINE-MACRO is now DEFMACRO. Also &uniform is now &uniforms. And various other
minor tweaks.


----

#